### PR TITLE
Create: 평균 평점 기준 영화 리스트 API 생성

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -1,3 +1,5 @@
-from django.urls import path
+from django.urls import path, include
 
-urlpatterns = []
+urlpatterns = [
+    path("", include("movies.urls")),
+]

--- a/movies/urls.py
+++ b/movies/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from .views import MovieListView
+
+urlpatterns = [
+    path("", MovieListView.as_view()),
+]

--- a/movies/views.py
+++ b/movies/views.py
@@ -12,7 +12,7 @@ class MovieListView(View):
         staff = request.GET.get("staff")
         title = request.GET.get("title")
         rating = request.GET.get("rating")
-        print(source)
+
         q = Q()
         if source:
             q.add(Q(sources__name=source), q.AND)

--- a/movies/views.py
+++ b/movies/views.py
@@ -1,3 +1,50 @@
-from django.shortcuts import render
+from django.http import JsonResponse
+from django.views import View
+from django.db.models import Q, Avg
+from .models import *
 
-# Create your views here.
+
+class MovieListView(View):
+    def get(self, request):
+        LIMIT = 15
+        OFFSET = 0
+        source = request.GET.get("source")
+        staff = request.GET.get("staff")
+        title = request.GET.get("title")
+        rating = request.GET.get("rating")
+        print(source)
+        q = Q()
+        if source:
+            q.add(Q(sources__name=source), q.AND)
+
+        if staff:
+            q.add(Q(staffs__name=staff), q.AND)
+
+        if title:
+            q.add(Q(title__icontains=title), q.AND)
+
+        if rating:
+            q = Q()
+
+        movies = (
+            Movie.objects.filter(q)
+            .annotate(average_point=Avg("rating__rate"))
+            .order_by("-average_point")[OFFSET:LIMIT]
+        )
+
+        result = {
+            "movies": [
+                {
+                    "id": movie.id,
+                    "title": movie.title,
+                    "poster_image_url": movie.poster_image_url,
+                    "released_at": movie.released_at,
+                    "country": movie.country,
+                    "ratings": movie.average_point,
+                    "sources": [source.name for source in movie.sources.all()],
+                }
+                for movie in movies
+            ]
+        }
+
+        return JsonResponse({"message": result}, status=200)

--- a/movies/views.py
+++ b/movies/views.py
@@ -10,10 +10,9 @@ class MovieListView(View):
         staff = request.GET.get("staff")
         title = request.GET.get("title")
         rating = request.GET.get("rating")
-        page = int(request.GET.get("page", 1))
+        OFFSET = int(request.GET.get("offset", 0))
         page_size = int(request.GET.get("display", 15))
-        LIMIT = page_size * page
-        OFFSET = LIMIT - page_size
+        LIMIT = OFFSET + page_size
 
         q = Q()
         if source:

--- a/movies/views.py
+++ b/movies/views.py
@@ -11,8 +11,7 @@ class MovieListView(View):
         title = request.GET.get("title")
         rating = request.GET.get("rating")
         OFFSET = int(request.GET.get("offset", 0))
-        page_size = int(request.GET.get("display", 15))
-        LIMIT = OFFSET + page_size
+        LIMIT = int(request.GET.get("display", 15))
 
         q = Q()
         if source:
@@ -30,7 +29,7 @@ class MovieListView(View):
         movies = (
             Movie.objects.filter(q)
             .annotate(average_point=Avg("rating__rate"))
-            .order_by("-average_point")[OFFSET:LIMIT]
+            .order_by("-average_point")[OFFSET : OFFSET + LIMIT]
         )
 
         result = {
@@ -45,7 +44,7 @@ class MovieListView(View):
                     "sources": [source.name for source in movie.sources.all()],
                 }
                 for movie in movies
-            ]
+            ],
         }
 
         return JsonResponse({"message": result}, status=200)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [x] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [x] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 평균 평점 기준으로 영화 리스트를 조회해주는 API를 생성

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 메인 페이지 영화 리스트 기능 구현
-  박스오피스, 왓챠, 넷플릭스 등 전달된 query parameter를 기준으로 영화 리스트 생성 후, 평균 평점 높은 순으로 전달하여 응답
<img width="1672" alt="스크린샷 2021-11-06 오후 8 05 19" src="https://user-images.githubusercontent.com/67135804/140607550-45ae5152-24c3-4323-b64d-afb8823cb8fb.png">
- query parameter로 rating이 전달되면, 전체 영화에서 평균 평점이 높은 순으로 영화 리스트 제공
- 영화는 최대 15개까지 평점 순으로 리스트화하여 제공

2. 검색 기능 구현
- 검색어를 입력하면, 해당 검색어가 제목에 포함된 영화를 평균 평점 순으로 리스트화하여 15개까지 전달
<img width="1705" alt="스크린샷 2021-11-06 오후 8 05 43" src="https://user-images.githubusercontent.com/67135804/140607559-9b46006c-24c7-469c-910b-52c7dc43e41b.png">


3. OFFSET, LIMIT 개념 이해
- OFFSET과  LIMIT을 고정 상수로 두지 않고, 프론트에서 요청된 query parameter의 값을 추출
- 추출한 값중 OFFSET은 Slice의 시작점이되고, LIMIT은 페이지당 보여줄 row의 수이기 떄문에 [OFFSET: OFFSET+LIMIT]으로 반환할 row의 수를 제어
<img width="1714" alt="스크린샷 2021-11-06 오후 8 10 17" src="https://user-images.githubusercontent.com/67135804/140607562-f7d10095-9fac-41e5-b518-c749890f556c.png">


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- Q객체를 add하여 사용하는 방법에 대해 익혔습니다. Q객체를 이용할 때, AND와 OR 사용방법에 대해 배웠습니다.
- annotate를 사용하여 Many-to-Many를 통해 참조 중인 평점을 찾아 평균을 구하는 방법에 대해서 알게되었습니다.
- 프론트에서 서버로 여러번의 request를 요청하여 그 응답결과를 가지고 페이지를 구성할 수 있다는 사실에서 대해서 알게되었습니다.
- API를 설계할 때 확장성을 가질 수 있도록 고민해야한다는 것에 대해 느꼈습니다.
- OFFSET과 LIMIT의 개념을 정확히 이해하고 사용할 수 있는 계기가 되었습니다.

<br />

## :: 기타 질문 및 특이 사항
- source 필드 및 테이블을 추후 platform으로 수정하여 마이그레이션 할 수 있도록 하겠습니다.