### PR TITLE
Modified: MovieListView 데이트터셋 수정 및 검색 기능 수정

### DIFF
--- a/movies/views.py
+++ b/movies/views.py
@@ -7,24 +7,32 @@ from .models import *
 class MovieListView(View):
     def get(self, request):
         source = request.GET.get("source")
-        staff = request.GET.get("staff")
-        title = request.GET.get("title")
         rating = request.GET.get("rating")
+        keyword = request.GET.get("keyword")
         OFFSET = int(request.GET.get("offset", 0))
         LIMIT = int(request.GET.get("display", 15))
 
+        category = {
+            "박스오피스": "박스오피스 영화 순위",
+            "왓챠": "왓챠 영화 순위",
+            "넷플릭스": "넷플릭스 영화 순위",
+            "평균별점": "평균별점이 높은 작품",
+        }
+
+        result = {}
+
         q = Q()
+
         if source:
             q.add(Q(sources__name=source), q.AND)
+            result["category"] = category[source]
 
-        if staff:
-            q.add(Q(staffs__name=staff), q.AND)
-
-        if title:
-            q.add(Q(title__icontains=title), q.AND)
+        if keyword:
+            q.add(Q(staffs__name__icontains=keyword) | Q(title__icontains=keyword), q.AND)
 
         if rating:
             q = Q()
+            result["category"] = category[rating]
 
         movies = (
             Movie.objects.filter(q)
@@ -32,19 +40,17 @@ class MovieListView(View):
             .order_by("-average_point")[OFFSET : OFFSET + LIMIT]
         )
 
-        result = {
-            "movies": [
-                {
-                    "id": movie.id,
-                    "title": movie.title,
-                    "poster_image_url": movie.poster_image_url,
-                    "released_at": movie.released_at,
-                    "country": movie.country,
-                    "ratings": round(movie.average_point, 1) if movie.average_point != None else 0,
-                    "sources": [source.name for source in movie.sources.all()],
-                }
-                for movie in movies
-            ],
-        }
+        result["movies"] = [
+            {
+                "id": movie.id,
+                "title": movie.title,
+                "poster_image_url": movie.poster_image_url,
+                "released_at": movie.released_at,
+                "country": movie.country,
+                "ratings": round(movie.average_point, 1) if movie.average_point != None else 0,
+                "sources": [source.name for source in movie.sources.all()],
+            }
+            for movie in movies
+        ]
 
         return JsonResponse({"message": result}, status=200)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [X] 기능 추가
- [X] 리뷰 반영
- [X] 리팩토링
- [ ] 버그 수정
- [X] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 평점순 영화 리스트를 제공 API 데이터셋 변경 및 검색 기능 일부 수정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 메인 페이지 영화 리스트 제공 API 구현
- query parameter로 source이 존재하면, 이 값이 "박스오피스", "왓챠", "넷플릭스", "전체평점"인지에 따라 해당 카테고리의 영화 리스트 제공
- 프론트엔드 목데이터 구조에 따른 데이터셋 수정 완료
<img width="1409" alt="스크린샷 2021-11-08 오후 7 08 32" src="https://user-images.githubusercontent.com/67135804/140723348-95cbada6-d9c0-47d9-83d5-e38aac49d5ac.png">


2. 검색 기능 수정
- 영화 제목 기준으로 검색하던 검색 API 기능을 영화 title 또는 staff 이름으로도 검색하여 무비 리스트를 제공할 수 있도록 확장
<img width="1404" alt="스크린샷 2021-11-08 오후 7 06 10" src="https://user-images.githubusercontent.com/67135804/140723370-f9b57485-ca77-4fda-b397-1cdc50936919.png">


<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 개발 기획 단계에서 프론트의 목데이터에 대해 좀 더 분명한 소통을 선행해야 겠다고 느꼈습니다.
- 데이터셋을 무조건 맞춰주는것이 아니라, 사전에 협의를 거쳐 백엔드 코드도 가독성 있게 작성될 수 있도록 유념하겠습니다.

<br />

## :: 기타 질문 및 특이 사항
- 감사합니다.